### PR TITLE
delete useMemo and add inline styles for Link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,15 @@ import { MainPagLazy } from './components/pages/MainPage/MainPage.lazy'
 import './styles/index.scss'
 import { useTheme } from './theme/useTheme'
 
-export default function App() {
+function App() {
 	const { theme, toggleTheme } = useTheme()
 
 	return (
 		<div className={`app ${theme}`}>
 			<button onClick={toggleTheme}>Change Theme</button>
-			<Link to={'/'}>Главная страница</Link>
+			<Link to={'/'} style={{ paddingLeft: '15px', paddingRight: '15px' }}>
+				Главная страница
+			</Link>
 			<Link to={'/about'}>О сайте</Link>
 			<Suspense fallback={<div>Загрузка...</div>}>
 				<Routes>
@@ -22,3 +24,5 @@ export default function App() {
 		</div>
 	)
 }
+
+export default App

--- a/src/theme/ThemeProvider.tsx
+++ b/src/theme/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 import { LOCAL_STORAGE_THEME_KEY, Theme, ThemeContext } from './themeContext'
 
 const defaultTheme =
@@ -7,22 +7,10 @@ const defaultTheme =
 const ThemeProvider: FC = ({ children }) => {
 	const [theme, setTheme] = useState<Theme>(defaultTheme)
 
-	const toggleTheme = () => {
-		setTheme(theme === Theme.DARK ? Theme.LIGHT : Theme.DARK)
-	}
-
-	const defaultProps = useMemo(
-		() => ({
-			theme: theme,
-			setTheme: setTheme,
-		}),
-		[theme]
-	)
 	return (
-		<ThemeContext.Provider value={defaultProps}>
+		<ThemeContext.Provider value={{ theme, setTheme }}>
 			{children}
 		</ThemeContext.Provider>
 	)
 }
-
 export default ThemeProvider


### PR DESCRIPTION
### **🇷🇺 Русский вариант**

**Что сделано:**

Удалён useMemo при передаче значения в ThemeContext.Provider, так как мемоизация для простого объекта с двумя полями излишня.

Для ссылок временно добавлены inline-стили (для отступов).

### **🇬🇧 English version**

**Changes:**

Removed useMemo for ThemeContext.Provider value, since memoization is unnecessary for a simple object with two fields.

Added temporary inline styles for links (padding).